### PR TITLE
Configured multi emails for landlords and referral agencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 
+gem 'devise-multi_email'
+
 # Uncomment this line with "bcrypt" in the same file:
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    devise-multi_email (2.0.1)
+      devise
     erubi (1.7.1)
     execjs (2.7.0)
     faker (1.9.1)
@@ -245,6 +247,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  devise-multi_email
   faker (~> 1.6, >= 1.6.6)
   figaro
   jbuilder (~> 2.5)

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,0 +1,4 @@
+class Email < ApplicationRecord
+	belongs_to :user, optional: true
+	validates :email, format: { with: Devise.email_regexp }, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,13 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
-  validates :name, :email, :type, :address, :phone, presence: true
-  validates :email, format: { with: Devise.email_regexp }
+  has_many :emails
+  validates :name, :emails, :type, :address, :phone, presence: true
   validates :type, inclusion: { in: ["Landlord", "ReferralAgency"] }
+  devise :multi_email_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable, 
+         :multi_email_confirmable, :multi_email_validatable
+
+	def will_save_change_to_email?
+	end
 end

--- a/db/migrate/20181031184135_create_emails.rb
+++ b/db/migrate/20181031184135_create_emails.rb
@@ -1,0 +1,13 @@
+class CreateEmails < ActiveRecord::Migration[5.2]
+  def change
+    create_table :emails do |t|
+      t.integer :user_id
+      t.string :email
+      t.boolean :primary, default: false
+      t.string :unconfirmed_email
+      t.string :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+    end
+  end
+end

--- a/db/migrate/20181031185050_remove_email_from_user.rb
+++ b/db/migrate/20181031185050_remove_email_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveEmailFromUser < ActiveRecord::Migration[5.2]
+  def change
+  	remove_column :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_27_200859) do
+ActiveRecord::Schema.define(version: 2018_10_31_185050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,16 @@ ActiveRecord::Schema.define(version: 2018_10_27_200859) do
     t.index ["info_id", "property_id"], name: "index_applications_on_info_id_and_property_id", unique: true
     t.index ["info_id"], name: "index_applications_on_info_id"
     t.index ["property_id"], name: "index_applications_on_property_id"
+  end
+
+  create_table "emails", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "email"
+    t.boolean "primary", default: false
+    t.string "unconfirmed_email"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
   end
 
   create_table "infos", force: :cascade do |t|
@@ -66,7 +76,6 @@ ActiveRecord::Schema.define(version: 2018_10_27_200859) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
@@ -81,7 +90,6 @@ ActiveRecord::Schema.define(version: 2018_10_27_200859) do
     t.string "address"
     t.string "phone"
     t.string "type"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/test/fixtures/emails.yml
+++ b/test/fixtures/emails.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/email_test.rb
+++ b/test/models/email_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EmailTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Allows landlords and referral agencies to have multiple email addresses associated with their account in our database. Tested via rails console.